### PR TITLE
Improvements

### DIFF
--- a/sandbox
+++ b/sandbox
@@ -170,10 +170,14 @@ sandbox () {
     docker-compose -f "$SANDBOX_DIR/docker-compose.yml" "$@"
   }
 
-  check_if_rebuild_needed () {
+  rebuild_if_needed () {
     if [ -f "$CLEAN_FILE" ]; then
       rm "$CLEAN_FILE"
-      REBUILD_STATEMENT="* docker-compose build --no-cache\n"
+      echo ".clean file found in sandbox directory. Rebuilding images..."
+      echo "* docker-compose build --no-cache"
+      dc build --no-cache             >> "$SANDBOX_LOG"
+    elif [ $FRESH_INSTALL -eq 0 ]; then
+      echo ".clean file NOT FOUND. Sandbox images will NOT be rebuilt."
     fi
   }
 
@@ -379,33 +383,19 @@ sandbox () {
       echo "$NEW_CONFIG" > "$ACTIVE_CONFIG_FILE"
       source "$CONFIG_FILE"
       if [ $INTERACTIVE_MODE == 1 ]; then
+        rebuild_if_needed
         dc up
       elif [ $VERBOSE_MODE == 0 ]; then
         echo "see sandbox.log for detailed progress, or use -v."
-        check_if_rebuild_needed
-        if [ ! -z ${REBUILD_STATEMENT+x} ]; then
-          echo -e ".clean file found in sandbox directory. Rebuilding images...\n" >> "$SANDBOX_LOG"
-          echo -e "${REBUILD_STATEMENT}" >> "$SANDBOX_LOG"
-          dc build --no-cache             >> "$SANDBOX_LOG" 2>&1 & spinner
-        elif [ $FRESH_INSTALL -eq 0 ]; then
-          echo -e ".clean file NOT FOUND. Sandbox images will NOT be rebuilt.\n" >> "$SANDBOX_LOG"
-        fi
-        echo "* docker-compose up -d"   >> "$SANDBOX_LOG"
         echo "" # The spinner will rewrite this line.
+        rebuild_if_needed >> "$SANDBOX_LOG" 2>&1               & spinner
+        echo "* docker-compose up -d"   >> "$SANDBOX_LOG"
         dc up -d                        >> "$SANDBOX_LOG" 2>&1 & spinner
         sleep 1                                                & spinner
         overwrite "* started!"
       else
-        check_if_rebuild_needed
-        if [ ! -z ${REBUILD_STATEMENT+x} ]; then
-          echo -e ".clean file found in sandbox directory. Rebuilding images...\n" >> "$SANDBOX_LOG"
-          echo -e "${REBUILD_STATEMENT}"
-          dc build --no-cache
-        elif [ $FRESH_INSTALL -eq 0 ]; then
-          echo -e ".clean file NOT FOUND. Sandbox images will NOT be rebuilt.\n"
-        fi
+        rebuild_if_needed
         echo "* docker-compose up -d"
-        echo "" # The spinner will rewrite this line.
         dc up -d
         sleep 1
       fi


### PR DESCRIPTION
* remove duplicate code and write a function "rebuild_if_needed"
* fix spinner to be displayed in an empty line
* use "echo" instead of "echo -e" when "echo -e" is not required
* remove end of line "\n" in "echo" when not necessary
* support for interactive mode as non-interactive mode